### PR TITLE
Warrior: Add Charge (slow) to Common.lua

### DIFF
--- a/rules/Common.lua
+++ b/rules/Common.lua
@@ -59,6 +59,7 @@ AdiButtonAuras:RegisterRules(function()
 				116095, -- Disable (monk, 1 stack)
 				127797, -- Ursol's Vortex
 				-- 129923  -- Sluggish (warrior, hs glyph) -- NOTE: gone in Legion
+				236027, -- Charge (warrior)
 			}
 		}, -- Snares and anti-snares
 


### PR DESCRIPTION
Harmful Aura: 236027 Charge (slow)

Introduced in patch 7.1.5:

- Charge now reduces the movement speed of the target by 50% for 6 seconds.

I also added a pull request for the Charge (slow) to LibPlayerSpells, see https://github.com/AdiAddons/LibPlayerSpells-1.0/pull/118.