### PR TITLE
Remove the dependency on LibDispellable-1.0

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -3,8 +3,8 @@ globals = {
 	"AceGUIWidgetLSMlists", "AdiButtonAuras", "AdiDebug", "LibStub",
 
 	-- ABA API
-	"AddRuleFor", "BuffAliases", "BuildAuraHandler_FirstOf", "BuildAuraHandler_Longest",
-	"BuildAuraHandler_Single", "BuildDesc", "BuildKey", "Configure", "DebuffAliases", "Debug",
+	"AddRuleFor", "BuffAliases", "BuildAuraHandler_FirstOf", "BuildAuraHandler_Longest", "BuildAuraHandler_Single",
+	"BuildDispelHandler", "BuildDesc", "BuildKey", "Configure", "DebuffAliases", "Debug",
 	"DescribeAllSpells", "DescribeAllTokens", "DescribeFilter", "DescribeHighlight",
 	"DescribeLPSSource", "GetBuff", "GetDebuff", "GetLib", "GetPlayerBuff", "GetPlayerDebuff",
 	"ImportPlayerSpells", "IterateBuffs", "IterateDebuffs", "IteratePlayerBuffs",

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -37,7 +37,6 @@ externals:
     tag: latest
   libs/LibSpellbook-1.0: https://github.com/AdiAddons/LibSpellbook-1.0.git
   libs/LibItemBuffs-1.0: https://github.com/AdiAddons/LibItemBuffs-1.0.git
-  libs/LibDispellable-1.0: https://github.com/AdiAddons/LibDispellable-1.0.git
   libs/LibPlayerSpells-1.0: https://github.com/AdiAddons/LibPlayerSpells-1.0.git
   SMBH: https://github.com/Adirelle/SharedMedia_ButtonHighlight.git
 

--- a/AdiButtonAuras.toc
+++ b/AdiButtonAuras.toc
@@ -28,7 +28,7 @@
 ## X-eMail: adirelle@gmail.com
 ## SavedVariables: AdiButtonAurasDB
 
-## OptionalDeps: Ace3, LibArtifactData-1.0, LibSpellbook-1.0, LibDispellable-1.0, LibItemBuffs-1.0, LibPlayerSpells-1.0, LibDualSpec-1.0, LibButtonGlow-1.0, LibSharedMedia-3.0, SharedMedia_ButtonHighlight, AdiDebug, Dominos, LibActionButton-1.0, LibActionButton-1.0-ElvUI, Bartender4, Masque
+## OptionalDeps: Ace3, LibArtifactData-1.0, LibSpellbook-1.0, LibItemBuffs-1.0, LibPlayerSpells-1.0, LibDualSpec-1.0, LibButtonGlow-1.0, LibSharedMedia-3.0, SharedMedia_ButtonHighlight, AdiDebug, Dominos, LibActionButton-1.0, LibActionButton-1.0-ElvUI, Bartender4, Masque
 
 #@no-lib-strip@
 libs\LibStub\LibStub.lua
@@ -36,7 +36,6 @@ libs\CallbackHandler-1.0\CallbackHandler-1.0.xml
 libs\BugGrabber\load.xml
 libs\AceDB-3.0\AceDB-3.0.xml
 libs\LibDualSpec-1.0\LibDualSpec-1.0.lua
-libs\LibDispellable-1.0\LibDispellable-1.0.lua
 libs\LibPlayerSpells-1.0\lib.xml
 libs\LibSharedMedia-3.0\lib.xml
 libs\LibButtonGlow-1.0\LibButtonGlow-1.0.lua

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Most of the simple (de)buffs are supported through embedded libraries:
 
  * most class and racial spells using [LibPlayerSpells-1.0](https://github.com/AdiAddons/LibPlayerSpells-1.0),
  * crowd-control spells using [LibPlayerSpells-1.0](https://github.com/AdiAddons/LibPlayerSpells-1.0),
- * dispel spells using [LibDispellable-1.0](https://github.com/AdiAddons/LibDispellable-1.0/),
+ * dispel spells using [LibPlayerSpells-1.0](https://github.com/AdiAddons/LibPlayerSpells-1.0),
  * trinket, enchantment and item buffs using [LibItemBuffs-1.0](https://github.com/AdiAddons/LibItemBuffs-1.0/).
 
 Special cases and hints are handled using customized rules, see below.
@@ -75,7 +75,6 @@ These are references to the libraries AdiButtonAuras used to create the rule.
 
  * LPS-XXX-A.B.C-N: data from [LibPlayerSpells-1.0](https://github.com/AdiAddons/LibPlayerSpells-1.0) for class XXX, patch A.B.C, Nth revision. E.g. "[LPS-DRUID-5.4.1-7]" stands for "rule created accordingly to LibPlayerSpells-1.0 data for druid, patch 5.4.1, 7th revision."
  * LSB-N: [LibSpellbook-1.0](https://github.com/AdiAddons/LibSpellbook-1.0), Nth revision.
- * LD-N: [LibDispellable-1.0](https://github.com/AdiAddons/LibDispellable-1.0/), Nth revision.
  * LIB-N-XXX: [LibItemBuffs-1.0](https://github.com/AdiAddons/LibItemBuffs-1.0/), Nth revision, XXX data version
 
 **Are you going to support ElvUI?**

--- a/core/AuraTools.lua
+++ b/core/AuraTools.lua
@@ -91,7 +91,7 @@ local playerAurasMetatable = {
 		_Update = function(self, unit, filter)
 			local serial = GetTime()
 			for index = 1, math.huge do
-				local name, _, count, _, _, expiration, _, _, _, id = UnitAura(unit, index, filter)
+				local name, _, count, dispel, _, expiration, _, _, _, id = UnitAura(unit, index, filter)
 				if not name then
 					break
 				end
@@ -101,6 +101,7 @@ local playerAurasMetatable = {
 					self[id] = aura
 				end
 				aura.count = count
+				aura.dispel = dispel
 				aura.expiration = expiration
 				aura.id = id
 				aura.serial = serial
@@ -124,7 +125,7 @@ local allAurasMetatable = {
 		CheckGUID = CheckGUID,
 		_Update = function(self, unit, filter)
 			for index = 1, math.huge do
-				local name, _, count, _, _, expiration, _, _, _, id = UnitAura(unit, index, filter)
+				local name, _, count, dispel, _, expiration, _, _, _, id = UnitAura(unit, index, filter)
 				if not name then
 					for i = index, #self do
 						self[i] = del(rawget(self, i))
@@ -137,6 +138,7 @@ local allAurasMetatable = {
 					self[index] = aura
 				end
 				aura.count = count
+				aura.dispel = dispel
 				aura.expiration = expiration
 				aura.id = id
 			end
@@ -234,7 +236,7 @@ local function auraIterator(auras, index)
 	repeat
 		nextIndex, aura = next(auras, nextIndex)
 		if type(nextIndex) == "number" then
-			return nextIndex, aura.id, aura.count, aura.expiration
+			return nextIndex, aura.id, aura.count, aura.expiration, aura.dispel
 		end
 	until not nextIndex
 end
@@ -248,7 +250,7 @@ for key in pairs(mts) do
 		if unit and UnitExists(unit) then
 			local aura = cache[unit][key]:CheckGUID():GetById(id)
 			if aura then
-				return id, aura.count, aura.expiration
+				return id, aura.count, aura.expiration, aura.dispel
 			end
 		end
 	end

--- a/core/Core.lua
+++ b/core/Core.lua
@@ -638,12 +638,12 @@ addon.dynamicUnitConditionals = dynamicUnitConditionals
 
 function addon:UpdateDynamicUnitConditionals()
 	local selfCast, focusCast = GetModifiedClick("SELFCAST"), GetModifiedClick("FOCUSCAST")
-	local enemy = "[harm]"
+	local enemy = "[@target,harm]"
 	local ally
 	if GetCVarBool("autoSelfCast") then
-		ally = "[help,nodead][@player]"
+		ally = "[@target,help,nodead][@player]"
 	else
-		ally = "[help]"
+		ally = "[@target,help]"
 	end
 	if focusCast ~= "NONE" then
 		enemy = "[@focus,mod:"..focusCast.."]"..enemy

--- a/core/Overlays.lua
+++ b/core/Overlays.lua
@@ -399,8 +399,8 @@ function overlayPrototype:UpdateDynamicUnits(event, unit)
 
 	for token, conditional in pairs(self.unitConditionals) do
 		local _, unit = SecureCmdOptionParse(conditional)
-		if not unit or unit == "" then
-			unit = "target"
+		if not unit then
+			unit = ""
 		elseif unit == "mouseover" then
 			local mouseoverUnit = addon:GetMouseoverUnit()
 			if mouseoverUnit == "mouseover" then

--- a/core/RuleDSL.lua
+++ b/core/RuleDSL.lua
@@ -643,7 +643,7 @@ local RULES_ENV = addon.BuildSafeEnv(
 	-- Allowed globals
 	{
 		-- lua
-		"bit", "ceil", "floor", "format", "ipairs", "math", "max", "min", "pairs", "print",
+		"bit", "ceil", "floor", "format", "ipairs", "math", "max", "min", "next", "pairs", "print",
 		"select", "string", "table", "tinsert", "type",
 		-- WoW API
 		"GetNumGroupMembers", "GetPetTimeRemaining", "GetRuneCooldown", "GetShapeshiftFormID",

--- a/core/RuleDSL.lua
+++ b/core/RuleDSL.lua
@@ -284,6 +284,19 @@ local function BuildAuraHandler_FirstOf(filter, highlight, token, buffs, callLev
 	end
 end
 
+local function BuildDispelHandler(filter, highlight, token, dispellable, callLevel)
+	local IterateAuras = addon.GetAuraIterator(filter)
+	local Show = GetHighlightHandler(highlight)
+	return function(units, model)
+		for _, _, count, expiration, dispel in IterateAuras(units[token]) do
+			if dispellable[dispel] then
+				Show(model, count, expiration)
+				return true
+			end
+		end
+	end
+end
+
 ------------------------------------------------------------------------------
 -- High-callLevel helpers
 ------------------------------------------------------------------------------
@@ -555,6 +568,7 @@ local baseEnv = {
 	BuildAuraHandler_Single  = BuildAuraHandler_Single,
 	BuildAuraHandler_Longest = BuildAuraHandler_Longest,
 	BuildAuraHandler_FirstOf = BuildAuraHandler_FirstOf,
+	BuildDispelHandler       = BuildDispelHandler,
 
 	-- Description helpers
 	BuildDesc         = addon.BuildDesc,
@@ -624,7 +638,7 @@ local RULES_ENV = addon.BuildSafeEnv(
 	baseEnv,
 	-- Allowed Libraries
 	{
-		"LibDispellable-1.0", "LibPlayerSpells-1.0", "LibSpellbook-1.0", "LibItemBuffs-1.0"
+		"LibPlayerSpells-1.0", "LibSpellbook-1.0", "LibItemBuffs-1.0"
 	},
 	-- Allowed globals
 	{


### PR DESCRIPTION
This made an old side effect visible:
- `overlayPrototype:UpdateDynamicUnits` assumed 'target' if `SecureCmdOptionParse` failed to retrieve a unit for a given condition.
- `SecureCmdOptionParse("[help]")` returns `"", nil` for a targeted friendly unit.
- Vise versa for "[harm]" and friendly units.

Together those resulted in the enemy pseudo unit to resolve to 'target' even for friendly units and thus leading to false positives for rules.

This can be made visible by the following rule:
```lua
Configure {
	"Execute",
	format(L["%s when %s is below %s%% health."], DescribeHighlight("hint"), DescribeAllTokens("enemy"), 20),
	{ 5308, 163201 }, -- Execute
	"enemy",
	{ "UNIT_HEALTH", "UNIT_MAXHEALTH" },
	function(units, model)
		local foe = units.enemy
		local maxHealth = UnitHealthMax(foe)
		if maxHealth <= 0 then return end
		if UnitHealth(foe) / maxHealth <= 0.20 then
			model.hint = true
		end
	end,
},
```
which will display the hint even for friendly units prior to this fix.

Using an empty string as a fallback in `overlayPrototype:UpdateDynamicUnits` feels hacky though. It works because Blizzard API that expects unit tokens handles empty strings well. Also the internal aura handlers do not check if the unit is nil, so it was a lazy fix. However this could spare us a few function calls, so it might be worth looking into it.