### PR TITLE
Shadowlands

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -13,7 +13,6 @@ globals = {
 	"ShowHealth", "ShowPower", "ShowStacks", "SimpleBuffs", "SimpleDebuffs",
 
 	-- WoW API
-	"ActionBarActionButtonMixin",
 	"GetNumGroupMembers", "GetPetTimeRemaining", "GetRuneCooldown", "GetShapeshiftFormID", "GetSpellBonusHealing",
 	"GetSpellCharges", "GetSpellCount", "GetSpellInfo", "GetTime", "GetTotemInfo", "HasPetSpells", "IsPlayerSpell",
 	"UnitCanAttack", "UnitCastingInfo", "UnitChannelInfo", "UnitClass", "UnitGUID", "UnitHealth", "UnitHealthMax",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -13,6 +13,7 @@ globals = {
 	"ShowHealth", "ShowPower", "ShowStacks", "SimpleBuffs", "SimpleDebuffs",
 
 	-- WoW API
+	"ActionBarActionButtonMixin",
 	"GetNumGroupMembers", "GetPetTimeRemaining", "GetRuneCooldown", "GetShapeshiftFormID", "GetSpellBonusHealing",
 	"GetSpellCharges", "GetSpellCount", "GetSpellInfo", "GetTime", "GetTotemInfo", "HasPetSpells", "IsPlayerSpell",
 	"UnitCanAttack", "UnitCastingInfo", "UnitChannelInfo", "UnitClass", "UnitGUID", "UnitHealth", "UnitHealthMax",

--- a/AdiButtonAuras.toc
+++ b/AdiButtonAuras.toc
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with AdiButtonAuras. If not, see <http://www.gnu.org/licenses/>.
 
-## Interface: 80300
+## Interface: 90000
 
 ## Title: AdiButtonAuras
 ## Notes: Display auras on action buttons.

--- a/AdiButtonAuras.toc
+++ b/AdiButtonAuras.toc
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with AdiButtonAuras. If not, see <http://www.gnu.org/licenses/>.
 
-## Interface: 90000
+## Interface: 90001
 
 ## Title: AdiButtonAuras
 ## Notes: Display auras on action buttons.

--- a/config/Spells.lua
+++ b/config/Spells.lua
@@ -117,7 +117,7 @@ function private.GetSpellOptions(addon, addonName)
 	-- Overlay prototype
 	------------------------------------------------------------------------------
 
-	local overlayPrototype = setmetatable({}, { __index = CreateFrame("Button") })
+	local overlayPrototype = setmetatable({}, { __index = CreateFrame("Button", nil, nil, 'BackdropTemplate') })
 	local overlayMeta = { __index = overlayPrototype }
 
 	local backdrop = {

--- a/core/Core.lua
+++ b/core/Core.lua
@@ -305,9 +305,12 @@ function addon:Initialize()
 	self:ScanButtons("StanceButton", NUM_STANCE_SLOTS)
 	self:ScanButtons("PetActionButton", NUM_PET_ACTION_SLOTS)
 
-	hooksecurefunc(ActionBarActionButtonMixin, 'Update', function(button)
-		return UpdateHandler('ActionButton_Update', button)
-	end)
+	for _, actionBarButton in next, _G.ActionBarButtonEventsFrame.frames do
+		hooksecurefunc(actionBarButton, 'Update', function(button)
+			return UpdateHandler('ActionButton_Update', button)
+		end)
+	end
+
 	hooksecurefunc('PetActionBar_Update', function()
 		for i = 1, NUM_PET_ACTION_SLOTS do
 			UpdateHandler('PetActionBar_Update', _G['PetActionButton'..i])

--- a/core/Core.lua
+++ b/core/Core.lua
@@ -305,7 +305,7 @@ function addon:Initialize()
 	self:ScanButtons("StanceButton", NUM_STANCE_SLOTS)
 	self:ScanButtons("PetActionButton", NUM_PET_ACTION_SLOTS)
 
-	hooksecurefunc('ActionButton_Update', function(button)
+	hooksecurefunc(ActionBarActionButtonMixin, 'Update', function(button)
 		return UpdateHandler('ActionButton_Update', button)
 	end)
 	hooksecurefunc('PetActionBar_Update', function()

--- a/core/DebugTooltip.lua
+++ b/core/DebugTooltip.lua
@@ -150,6 +150,12 @@ local function AddItemRefInfo(link)
 	return AddSpellInfo(_G.ItemRefTooltip, "spell", id, true)
 end
 
+local function AddConduitInfo(tooltip, conduitID, conduitRank)
+	local spellID = _G.C_Soulbinds.GetConduitSpellID(conduitID, conduitRank)
+	tooltip:AddLine(' ')
+	tooltip:AddDoubleLine('Conduit spell id:', spellID)
+end
+
 local proto = getmetatable(GameTooltip).__index
 hooksecurefunc(proto, "SetUnitAura", function(...) return AddAuraInfo(UnitAura, ...) end)
 hooksecurefunc(proto, "SetUnitBuff", function(...) return AddAuraInfo(UnitBuff, ...) end)
@@ -162,4 +168,5 @@ hooksecurefunc(proto, "SetArtifactPowerByID", AddArtifactInfo)
 hooksecurefunc(proto, "SetTalent", AddTalentInfo)
 hooksecurefunc(proto, 'SetPvpTalent', AddPvpTalentInfo)
 hooksecurefunc(proto, "SetAzeritePower", AddAzeriteInfo)
+hooksecurefunc(proto, 'SetConduit', AddConduitInfo)
 hooksecurefunc("SetItemRef", AddItemRefInfo)

--- a/core/RuleDSL.lua
+++ b/core/RuleDSL.lua
@@ -539,10 +539,28 @@ do
 	local IMPORTANT = LibPlayerSpells.constants.IMPORTANT
 	local SOURCE = LibPlayerSpells.masks.SOURCE
 
+	local function WarnOnStaleData(category)
+		local _, patch = LibPlayerSpells:GetVersionInfo(category)
+		local _, _, _, build = _G.GetBuildInfo()
+
+		if math.floor(patch / 1e4) < math.floor(build / 1e4) then
+			print(
+				format(
+					'%s |cffe7c82aThe spell data for %s is for the previous expansion and is inaccurate.|r',
+					format('|cff00ccff%s:|r', addonName),
+					category
+				)
+			)
+		end
+	end
+
 	function ImportPlayerSpells(category, ...)
 		if not LibPlayerSpells.__categories[category] then
 			error(format("Invalid category for ImportPlayerSpells: %s", category))
 		end
+
+		WarnOnStaleData(category)
+
 		local categoryMask = LibPlayerSpells.constants[category]
 		local exceptions = AsSet({...}, "number", 3)
 		local builders = {}

--- a/core/RuleDSL.lua
+++ b/core/RuleDSL.lua
@@ -95,8 +95,7 @@ local function SpellOrItemId(value, callLevel)
 	if spellId then
 		local name = GetSpellInfo(spellId)
 		if not name then
-			Debug(format("Invalid spell identifier: %s", value))
-			return
+			error(format("Invalid spell identifier: %s", tostring(value)), callLevel+1)
 		end
 		return format("spell:%d", spellId), "spell "..(GetSpellLink(spellId) or spellId), name, "spell", spellId
 	end
@@ -105,7 +104,7 @@ local function SpellOrItemId(value, callLevel)
 		local name, link = GetItemInfo(itemId)
 		return format("item:%d", itemId), link and ("item "..tostring(link)) or value, name or value, "item"
 	end
-	Debug(format("Invalid spell or item identifier: %s", value))
+	error(format("Invalid spell or item identifier: %s", tostring(value)), callLevel+1)
 end
 
 local function CheckAvailability(info, spellId, providers)

--- a/core/RuleDSL.lua
+++ b/core/RuleDSL.lua
@@ -95,7 +95,8 @@ local function SpellOrItemId(value, callLevel)
 	if spellId then
 		local name = GetSpellInfo(spellId)
 		if not name then
-			error(format("Invalid spell identifier: %s", tostring(value)), callLevel+1)
+			Debug(format("Invalid spell identifier: %s", value))
+			return
 		end
 		return format("spell:%d", spellId), "spell "..(GetSpellLink(spellId) or spellId), name, "spell", spellId
 	end
@@ -104,7 +105,7 @@ local function SpellOrItemId(value, callLevel)
 		local name, link = GetItemInfo(itemId)
 		return format("item:%d", itemId), link and ("item "..tostring(link)) or value, name or value, "item"
 	end
-	error(format("Invalid spell or item identifier: %s", tostring(value)), callLevel+1)
+	Debug(format("Invalid spell or item identifier: %s", value))
 end
 
 local function CheckAvailability(info, spellId, providers)

--- a/modules/AdiButtonAuras_Config/AdiButtonAuras_Config.toc
+++ b/modules/AdiButtonAuras_Config/AdiButtonAuras_Config.toc
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with AdiButtonAuras. If not, see <http://www.gnu.org/licenses/>.
 
-## Interface: 80300
+## Interface: 90000
 
 ## Title: AdiButtonAuras - Configuration
 ## Notes: Load-on-demand configuration GUI.

--- a/modules/AdiButtonAuras_Config/AdiButtonAuras_Config.toc
+++ b/modules/AdiButtonAuras_Config/AdiButtonAuras_Config.toc
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with AdiButtonAuras. If not, see <http://www.gnu.org/licenses/>.
 
-## Interface: 90000
+## Interface: 90001
 
 ## Title: AdiButtonAuras - Configuration
 ## Notes: Load-on-demand configuration GUI.

--- a/rules/Demonhunter.lua
+++ b/rules/Demonhunter.lua
@@ -28,16 +28,7 @@ AdiButtonAuras:RegisterRules(function()
 	return {
 		ImportPlayerSpells {
 			-- import all spells for
-			'DEMONHUNTER',
-			-- except for
-			203981, -- Soul Fragments
-		},
-
-		ShowStacks {
-			263648, -- Soul Barrier
-			203981, -- Soul Fragments
-			5,
-			'player',
+			'DEMONHUNTER'
 		},
 
 		ShowDispellable {

--- a/rules/Monk.lua
+++ b/rules/Monk.lua
@@ -28,14 +28,16 @@ AdiButtonAuras:RegisterRules(function()
 
 	local blackOxStatue = 627607
 	local jadeSerpentStatue = 620831
+	local jadeSerpent = 574571
+	local redCrane = 877514
 
-	local function BuildTotemHandler(statue)
+	local function BuildTotemHandler(totem)
 		return function(_, model)
-			-- monk have two totems at most
-			-- BUG: statues override pets on Beta
-			for slot = 1, 2 do
+			-- statues fill the first free slot when re-cast
+			-- due to statues' cooldowns the highest totem slot is 3
+			for slot = 1, 3 do
 				local found, _, start, duration, texture = GetTotemInfo(slot)
-				if found and texture == statue then
+				if found and texture == totem then
 					model.highlight = 'good'
 					model.expiration = start + duration
 					return
@@ -92,7 +94,6 @@ AdiButtonAuras:RegisterRules(function()
 			{
 				123904, -- Invoke Xuen, the White Tiger (Windwalker talent)
 				132578, -- Invoke Niuzao, the Black Ox (Brewmaster talent)
-				198664, -- Invoke Chi-Ji, the Red Crane (Mistweaver talent)
 			},
 			'player',
 			'UNIT_PET',
@@ -103,6 +104,24 @@ AdiButtonAuras:RegisterRules(function()
 					model.highlight = 'good'
 				end
 			end,
+		},
+
+		Configure {
+			'JadeSerpentPet',
+			L['Show the duration of @NAME.'],
+			322118, -- Invoke Yu'lon, the Jade Serpent (Mistweaver)
+			'player',
+			'PLAYER_TOTEM_UPDATE',
+			BuildTotemHandler(jadeSerpent)
+		},
+
+		Configure {
+			'RedCranePet',
+			L['Show the duration of @NAME.'],
+			325197, -- Invoke Chi-Ji, the Red Crane (Mistweaver talent)
+			'player',
+			'PLAYER_TOTEM_UPDATE',
+			BuildTotemHandler(redCrane)
 		},
 
 		Configure {

--- a/rules/Paladin.lua
+++ b/rules/Paladin.lua
@@ -39,8 +39,6 @@ AdiButtonAuras:RegisterRules(function()
 			 25771, -- Forbearance
 			 31935, -- Avenger's Shield (Protection)
 			188370, -- Consecration (Protection)
-			203538, -- Greater Blessing of Kings (Retribution)
-			203539, -- Greater Blessing of Wisdom (Retribution)
 			204018, -- Blessing of Spellwarding (Protection talent)
 			209785, -- Fires of Justice (Retribution talent)
 			269571, -- Zeal (Retribution talent)
@@ -52,9 +50,7 @@ AdiButtonAuras:RegisterRules(function()
 				 85256, -- Templar's Verdict (Retribution)
 				 53385, -- Divine Storm (Retribution)
 				 84963, -- Inquisition (Retribution talent)
-				210191, -- Word of Glory (Retribution talent)
 				215661, -- Justicar's Vengeance (Retribution talent)
-				267798, -- Execution Sentence (Retribution talent)
 			},
 			'HolyPower'
 		},
@@ -197,64 +193,6 @@ AdiButtonAuras:RegisterRules(function()
 				if found then
 					model.expiration = start + duration
 					model.highlight = GetPlayerBuff('player', 188370) and 'good' or nil
-				end
-			end,
-		},
-
-		Configure {
-			'GreaterBlessingOfKings',
-			format('%s %s',
-				format(
-					L['%s when %s @NAME is not found on a group member.'],
-					DescribeHighlight('hint'),
-					DescribeFilter('HELPFUL PLAYER')
-				),
-				BuildDesc('HELPFUL PLAYER', 'good', 'group', 203538)
-			),
-			203538, -- Greater Blessing of Kings (Retribution)
-			'group',
-			{'GROUP_ROSTER_UPDATE', 'UNIT_AURA'},
-			function(units, model)
-				local found, _, expiration
-				for unit in next, units.group do
-					found, _, expiration = GetPlayerBuff(unit, 203538)
-					if found then
-						model.highlight = 'good'
-						model.expiration = expiration
-						break
-					end
-				end
-				if not found then
-					model.hint = true
-				end
-			end,
-		},
-
-		Configure {
-			'GreaterBlessingOfWisdom',
-			format('%s %s',
-				format(
-					L['%s when %s @NAME is not found on a group member.'],
-					DescribeHighlight('hint'),
-					DescribeFilter('HELPFUL PLAYER')
-				),
-				BuildDesc('HELPFUL PLAYER', 'good', 'group', 203539)
-			),
-			203539, -- Greater Blessing of Kings (Retribution)
-			'group',
-			{'GROUP_ROSTER_UPDATE', 'UNIT_AURA'},
-			function(units, model)
-				local found, _, expiration
-				for unit in next, units.group do
-					found, _, expiration = GetPlayerBuff(unit, 203539)
-					if found then
-						model.highlight = 'good'
-						model.expiration = expiration
-						break
-					end
-				end
-				if not found then
-					model.hint = true
 				end
 			end,
 		},


### PR DESCRIPTION
Dependencies:
----------------

[LibPlayerSpells-1.0](https://github.com/AdiAddons/LibPlayerSpells-1.0/pull/137)
[LibSpellbook-1.0](https://github.com/AdiAddons/LibSpellbook-1.0/pull/9)

[LibItemBuffs-1.0](https://github.com/AdiAddons/LibItemBuffs-1.0) - due to changes on wowhead the spell scanner is broken since BfA. If someone has a solution for this, please speak up, else I'll keep the old items data which might be incorrect und will be incomplete.

How to help
-------------

Most of the work needs to be done in LibPlayerSpells. If you would like to help with the class data, please read the [contribution guidelines](https://github.com/AdiAddons/LibPlayerSpells-1.0/wiki/Contribution-Guidelines).

You will need to fork AdiButtonAuras and the aforementioned dependencies and check out their respective `shadowlands` branches (if present). You will also need the other ABA dependencies (see https://github.com/AdiAddons/AdiButtonAuras/wiki/Contributing)