### PR TITLE
Fix lockup with ww/bm monk celestials by using the buff times.

### DIFF
--- a/rules/Monk.lua
+++ b/rules/Monk.lua
@@ -88,22 +88,12 @@ AdiButtonAuras:RegisterRules(function()
 			196736, -- Blackout Combo (Brewmaster talent)
 		},
 
-		Configure {
-			'InvokePet',
-			L['Show the duration of @NAME.'],
-			{
-				123904, -- Invoke Xuen, the White Tiger (Windwalker talent)
-				132578, -- Invoke Niuzao, the Black Ox (Brewmaster talent)
-			},
-			'player',
-			'UNIT_PET',
-			function(_, model)
-				local remaining = GetPetTimeRemaining()
-				if remaining then
-					model.expiration = GetTime() + remaining / 1000
-					model.highlight = 'good'
-				end
-			end,
+		SelfBuffAliases {
+			123904, -- Invoke Xuen, the White Tiger
+		},
+
+		SelfBuffAliases {
+			132578, -- Invoke Niuzao, the Black Ox
 		},
 
 		Configure {


### PR DESCRIPTION
Still an issue with InvokePet / UNIT_PET / GetPetTimeRemaining that this doesn't resolve. I don't know what that problem really is.

But at least it doesn't lockup when the celestials expire any more.