### PR TITLE
Limit Maximum pet remaining time to 10 min

### DIFF
--- a/rules/Shaman.lua
+++ b/rules/Shaman.lua
@@ -40,6 +40,9 @@ local function BuildTempPetHandler(id)
 		if guid and guid:match('%-' .. id .. '%-') then
 			local remaining = GetPetTimeRemaining()
 			if remaining then
+				if remaining > 600000 then
+					remaining = 600000
+				end
 				model.expiration = GetTime() + remaining / 1000
 				model.highlight = 'good'
 			end


### PR DESCRIPTION
This should never happen, but with Shaman 4Pc the remaining pet time being returned sometimes gets buggy and counts to infinity crashing the game. This limits that. Not Elegant but I haven't had time to level my shaman to more deeply test what conditions the API incorrectly returns.

This Should Address #397 